### PR TITLE
概要

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ capybara-*.html
 rerun.txt
 pickle-email-*.html
 erd.pdf
-
+config/initializers/active_model_serializers.rb
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,16 @@
+module Api::V1
+  class ArticlesController < BaseApiController
+    def index
+      articles = Article.order(updated_at: :desc)
+
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+
+    end
+
+    def show
+      article = Article.find(params[:id])
+      render json: article
+    end
+
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -25,5 +25,4 @@ class Article < ApplicationRecord
   # validation
   validates :title, :content, presence: true
   validates :content, length: { maximum: 2000 }
-  validates :title, uniqueness: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@
 class User < ActiveRecord::Base
   has_many :articles, dependent: :destroy
   has_many :comments, dependent: :destroy
-  has_one :likes, dependent: :destroy
+  has_many :likes, dependent: :destroy
 
   # validation
   validates :user, presence: true

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :title, :updated_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -26,46 +26,6 @@
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #
-require "rails_helper"
-
-RSpec.describe User, type: :model do
-  fcontext "emailとpasswordに漏れがない場合かつuser（名前）が二文字以上なら" do
-    let(:user) {create(:user)}
-      binding.pry
-    fit "アカウントが作成される" do
-      expect(user).to be_valid
-    end
-  end
-
-  context "userが空欄だった場合" do
-    let(:user) {build(:user, user: nil,)}
-    it "アカウントが作成されない" do
-    end
-  end
-
-  context "名前のみ入力している場合" do
-    let(:user) { build(:user, email: nil, password: nil) }
-
-    it "エラーが発生する" do
-      binding.pry
-      expect(user).not_to be_valid
-    end
-  end
-
-  context "email がない場合" do
-    let(:user) { build(:user, email: nil) }
-
-    it "エラーが発生する" do
-      expect(user).not_to be_valid
-    end
-  end
-
-  context "password がない場合" do
-    let(:user) { build(:user, password: nil) }
-
-    it "エラーが発生する" do
-      expect(user).not_to be_valid
-    end
-  end
-
+class Api::V1::UserSerializer < ActiveModel::Serializer
+  attributes :id, :user, :email
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,8 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for "User", at: "auth"
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  namespace 'api' do
-    namespace 'v1' do
-      resources :articles do
-      end
+  namespace :api do
+    namespace :v1 do
+      mount_devise_token_auth_for "User", at: "auth"
+      resources :articles
     end
   end
-
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -19,8 +19,8 @@
 #
 FactoryBot.define do
   factory :article do
-    title { "MyString" }
-    content { "MyText" }
-    user_id { nil }
+    title { Faker::Lorem.word }
+    content { Faker::Lorem.sentence }
+    user
   end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Articles", type: :request do
+    fdescribe "GET /articles" do
+      let!(:article1) { create(:article, updated_at: 1.days.ago) }
+      let!(:article2) { create(:article, updated_at: 2.days.ago) }
+      let!(:article3) { create(:article) }
+
+
+      #before {create(:article)}
+       subject { get(api_v1_articles_path) }
+
+
+       it "記事の一覧が取得できる" do
+
+        subject
+        #binding.pry
+       res = JSON.parse(response.body)
+        binding.pry
+        expect(response).to have_http_status(200)
+        expect(res["articles"].length).to eq 3
+        expect(res["articles"][0].keys).to eq [ "title", "updated_at", "user"]
+        expect(res["articles"][0]["user"].keys).to eq [ "id","user", "email"]
+      end
+end
+
+# describe "GET/articles/:id" do
+
+#   subject{get(api_v1_articles_path(article_id))}
+#   let(:user_id) { article.id }
+#   let(:article) {FactoryBot.create(:article)}
+
+#   it "記事の詳細を表示させる" do
+#     subject
+#     binding.pry
+#     expect(response).to have_http_status(200)
+#     expect()
+#   end
+#end
+
+end


### PR DESCRIPTION
・task7-3完了&task7-4進行中
-task7-3ではarticle_preview_serializerとuser_serializerを作成し、articlesのJSONで返ってくる値を設定した。
-記事一覧表示とその他のレスポンスを分けるためにapi/v1/articles_controllerを作成した。
-コントローラーの階層を合わせるためにserializerもapp/serializer/api/v1/に作成した。
-articlesに誰が書いた記事かを出力させるためにuser_serializerをarticles_previewserializerと一緒にデータが抽出されるように設定。
-articles_controllerにはどのserializerを読み込むかの設定とindex メソッドの実装。
-request specでindexがちゃんと機能しているかの確認。